### PR TITLE
Add a print stylesheet which hides the lloyd.io header

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -1,0 +1,3 @@
+#header {
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <title> lloyd.io - lloyd's blog. </title>
   <link rel="stylesheet" href="css/zenburn.css" type="text/css">
   <link rel="stylesheet" href="css/style.css"  type="text/css">
+  <link rel="stylesheet" href="css/print.css"  type="text/css" media="print">
   <link title="lloyd.io: Lloyd Hilaiel's's blog" type="application/atom+xml" href="http://lloyd.io/feed.atom" rel="alternate">
   <script src="js/libs.js"></script>
   <meta name="ttw" content="35t2p1r" />


### PR DESCRIPTION
Without this, blog posts have a translucent header at the top of every page which hides the first sentence or two.
