### PR TITLE
Fixing a dead link (developers integration tutorial)

### DIFF
--- a/posts/2011-07-01-how-browserid-works.md
+++ b/posts/2011-07-01-how-browserid-works.md
@@ -28,7 +28,7 @@ proposed by Mike Hanson], and refined by [Dan Mills] and others).
 > tutorial] for a website developer's perspective.
 
   [myfavoritebeer.org]:http://myfavoritebeer.org
-  [integration tutorial]:https://browserid.org/developers.html
+  [integration tutorial]:https://developer.mozilla.org/en/BrowserID/Quick_Setup
 
 This post aims to provide a readable technical overview of the system.
 First it will summarize the key design elements of BrowserID.  Next,


### PR DESCRIPTION
https://browserid.org/developers.html doesn't exist anymore (it looks like it's been moved to MDN) but since your original blog post has been linked to from a lot of places, it might be worth updating that link.
